### PR TITLE
feat: add role to install Node.js

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,8 +1,10 @@
 Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/bionic64"
 
+  # Installs Docker
   config.vm.provision "docker"
 
+  # Removes package unattended-upgrades
   config.vm.provision "shell", inline: "sudo apt-get -qq remove unattended-upgrades"
 
   config.vm.provision "ansible_local" do |ansible|

--- a/playbook.yml
+++ b/playbook.yml
@@ -3,4 +3,5 @@
   hosts: all
   roles:
     - pip
+    - nodejs
     - linux

--- a/roles/nodejs/tasks/main.yml
+++ b/roles/nodejs/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+- name: Add Node.js signing key
+  apt_key:
+    state: present
+    url: https://deb.nodesource.com/gpgkey/nodesource.gpg.key
+
+- name: Add Node.js repositories
+  apt_repository:
+    repo: "{{ item }}"
+    state: present
+  with_items:
+    - deb https://deb.nodesource.com/node_12.x {{ ansible_distribution_release }} main
+    - deb-src https://deb.nodesource.com/node_12.x {{ ansible_distribution_release }} main
+
+- name: Install Node.js
+  apt:
+    name:
+      - nodejs
+    state: present
+    update_cache: true


### PR DESCRIPTION
hopdrops/hopdrops#78 requires Node.js and npm.

To use the new box, invoke the following commands (in the [hopdrops](https://github.com/hopdrops/hopdrops) repository):

    $ vagrant box remove bionic64
    $ vagrant up